### PR TITLE
Bug fixes: Zip code entry

### DIFF
--- a/web/src/view/nav/route.ts
+++ b/web/src/view/nav/route.ts
@@ -13,15 +13,15 @@ export enum Route {
 }
 
 export enum PlaygroundApp {
-  // SURVEYS = 'surveys',
+  SURVEYS = 'surveys',
   LOGIN = 'login',
   SIGNUP = 'signup',
 }
 
-// export function getSurveyPath(surveyId?: number) {
-//   const path = getPath(Route.PLAYGROUND_APP, { app: PlaygroundApp.SURVEYS })
-//   return path + (surveyId ? `?surveyId=${surveyId}` : '')
-// }
+export function getSurveyPath(surveyId?: number) {
+  const path = getPath(Route.PLAYGROUND_APP, { app: PlaygroundApp.SURVEYS })
+  return path + (surveyId ? `?surveyId=${surveyId}` : '')
+}
 
 export function getLoginPath() {
   return getPath(Route.PLAYGROUND_APP, { app: PlaygroundApp.LOGIN })

--- a/web/src/view/page/HikingPage.tsx
+++ b/web/src/view/page/HikingPage.tsx
@@ -160,10 +160,15 @@ export default class HikingPage extends Component<HikesPageProps> {
               variant="outlined"
               label="Zipcode"
               value={this.state.zip}
-              error={this.state.zip.length !== 5 && this.state.zip.length !== 0}
+              error={
+                this.state.zip.length !== 0 && (this.state.zip.length !== 5 || /^\d+$/.test(this.state.zip) == false)
+              }
               onChange={this.handleZipChange}
             />
-            <Button disabled={this.state.zip.length !== 5} onClick={this.handleLatLonChange}>
+            <Button
+              disabled={this.state.zip.length !== 5 || /^\d+$/.test(this.state.zip) == false}
+              onClick={this.handleLatLonChange}
+            >
               Submit
             </Button>
             <GetLatLon>{({ data, error, loading }: any) => console.log(data)}</GetLatLon>

--- a/web/src/view/page/HikingPage.tsx
+++ b/web/src/view/page/HikingPage.tsx
@@ -127,15 +127,11 @@ export default class HikingPage extends Component<HikesPageProps> {
   handleZipChange(event: any) {
     this.setState({ zip: event.target.value })
   }
-  handleLatLonChange() {
+  handleLatLonChange(event: any) {
     getHikesButton = true
-    return (
-      <div>
-        {(zipcode = Number(this.state.zip))}
-        <GetLatLon>{({ data, error, loading }: any) => console.log(data)}</GetLatLon>
-        {this.setState({ lat: lat, lon: lon })}
-      </div>
-    )
+    zipcode = Number(this.state.zip)
+    this.setState({ lat: lat, lon: lon })
+    event.preventDefault()
   }
   render() {
     const hikes = this.state.trails


### PR DESCRIPTION
Bug fixes related to the entering of the zip code:
- Added zip code validation (prevent alphabetic characters in zip code entry)
- Fixed a bug where when you pressed `Enter` after entering a valid zip code, the entire page would reload and the changes would not be saved 
    - Now, after pressing `Enter` with a valid zip code, the proper course of action (lat/lon conversion) is taken, and the `Get Hikes` button appears

Also bug fixes with import errors for surveys (unused)